### PR TITLE
Replacing pyRAF

### DIFF
--- a/MOSFIRE/IO.py
+++ b/MOSFIRE/IO.py
@@ -19,6 +19,8 @@ import os
 import pdb
 import shutil
 
+import ccdproc
+
 import MOSFIRE
 import CSU
 import Options

--- a/MOSFIRE/IO.py
+++ b/MOSFIRE/IO.py
@@ -541,6 +541,9 @@ def floatcompress(data, ndig=14):
     return out
 
 def imarith(operand1, op, operand2, result):
+    imarith_noiraf(operand1, op, operand2, result)
+
+def imarith_iraf(operand1, op, operand2, result):
     from pyraf import iraf
     iraf.images()
 
@@ -590,6 +593,11 @@ def imarith_noiraf(operand1, op, operand2, result):
     hdu.writeto(result)
 
 def imcombine(filelist, out, options, bpmask=None, reject="none", nlow=None,
+        nhigh=None):
+    imcombine_noiraf(filelist, out, options, bpmask=bpmask, reject="none", nlow=nlow, nhigh=nlow)
+
+
+def imcombine_iraf(filelist, out, options, bpmask=None, reject="none", nlow=None,
         nhigh=None):
 
     '''Convenience wrapper around IRAF task imcombine

--- a/MOSFIRE/IO.py
+++ b/MOSFIRE/IO.py
@@ -642,7 +642,81 @@ def imcombine(filelist, out, options, bpmask=None, reject="none", nlow=None,
     iraf.imcombine.setParList(pars)
 
 
+def imcombine_noiraf(filelist, out, options, bpmask=None, reject="none", nlow=None,
+        nhigh=None):
+    '''Replacement for iraf.imcombine which uses the ccdproc.combine method.
+
+    Args:
+        filelist: The list of files to imcombine
+        out: The full path to the output file
+        options: Options dictionary
+        bpmask: The full path to the bad pixel mask
+        reject: none, minmax, sigclip, avsigclip, pclip
+        nlow,nhigh: Parameters for minmax rejection, see iraf docs
     
+    Returns:
+        None
+
+    Side effects:
+        Creates the imcombined file at location `out'
+    '''
+    if reject == 'none':
+        ccdproc.combine(filelist, out, method='average',\
+                        minmax_clip=False,\
+                        sigma_clip=False)
+    elif reject == 'minmax':
+        ## The IRAF imcombine parameter for minmax rejection specifies the
+        ## number of pixels to clip, while the analogous parameters for
+        ## ccdproc.combine specify the pixel values above and below which to
+        ## clip, so a conversion will have to be made.
+        ##
+        ## From IRAF (help imcombine):
+        ##  nlow = 1,  nhigh = 1 (minmax)
+        ##      The number of  low  and  high  pixels  to  be  rejected  by  the
+        ##      "minmax"  algorithm.   These  numbers are converted to fractions
+        ##      of the total number of input images so  that  if  no  rejections
+        ##      have  taken  place  the  specified number of pixels are rejected
+        ##      while if pixels have been rejected by masking, thresholding,  or
+        ##      non-overlap,   then   the  fraction  of  the  remaining  pixels,
+        ##      truncated to an integer, is used.
+        ##
+        ## From ccdproc.combine doc string:
+        ##  minmax_clip : Boolean (default False)
+        ##      Set to True if you want to mask all pixels that are below
+        ##      minmax_clip_min or above minmax_clip_max before combining.
+        ##  
+        ##      Parameters below are valid only when minmax_clip is set to True.
+        ##  
+        ##      minmax_clip_min: None, float
+        ##           All pixels with values below minmax_clip_min will be masked.
+        ##      minmax_clip_max: None or float
+        ##           All pixels with values above minmax_clip_max will be masked.
+        raise NotImplementedError('minmax rejection is not yet implemented')
+#         clip_min = 
+#         clip_max = 
+#         ccdproc.combine(filelist, out, method='average',\
+#                         minmax_clip=True,\
+#                         minmax_clip_min=clip_min, minmax_clip_max=clip_max,\
+#                         sigma_clip=False)
+    elif reject == 'sigclip':
+        raise NotImplementedError('sigclip rejection is not yet implemented')
+#         ccdproc.combine(filelist, out, method='average',\
+#                         minmax_clip=False,\
+#                         sigma_clip=True,\
+#                         sigma_clip_low_thresh=
+#                         sigma_clip_high_thresh=
+#                         sigma_clip_func=np.mean,\
+#                         sigma_clip_dev_func=np.std,\
+#                         )
+    elif reject == 'avsigclip':
+        raise NotImplementedError('avsigclip rejection is not yet implemented')
+    elif reject == 'pclip':
+        raise NotImplementedError('pclip rejection is not yet implemented')
+    else:
+        raise NotImplementedError('{} rejection unrecognized by MOSFIRE DRP'.format(reject))
+
+
+
 
 class TestIOFunctions(unittest.TestCase):
 

--- a/MOSFIRE/IO.py
+++ b/MOSFIRE/IO.py
@@ -671,10 +671,15 @@ def imcombine_noiraf(filelist, out, options, bpmask=None, reject="none", nlow=No
         Creates the imcombined file at location `out'
     '''
     if reject == 'none':
+        info('Combining files using ccdproc.combine task')
+        info('  reject=none')
+        for file in filelist:
+            info('  {}'.format(file))
         ccdproc.combine(filelist, out, method='average',\
                         minmax_clip=False,\
                         sigma_clip=False,\
                         unit="adu")
+        info('  Done.')
     elif reject == 'minmax':
         ## The IRAF imcombine parameter for minmax rejection specifies the
         ## number of pixels to clip, while the analogous parameters for

--- a/MOSFIRE/IO.py
+++ b/MOSFIRE/IO.py
@@ -673,7 +673,8 @@ def imcombine_noiraf(filelist, out, options, bpmask=None, reject="none", nlow=No
     if reject == 'none':
         ccdproc.combine(filelist, out, method='average',\
                         minmax_clip=False,\
-                        sigma_clip=False)
+                        sigma_clip=False,\
+                        unit="adu")
     elif reject == 'minmax':
         ## The IRAF imcombine parameter for minmax rejection specifies the
         ## number of pixels to clip, while the analogous parameters for

--- a/MOSFIRE/IO.py
+++ b/MOSFIRE/IO.py
@@ -13,7 +13,7 @@ import numpy as np
 import unittest
 import warnings
 
-
+import re
 
 import os
 import pdb
@@ -561,6 +561,13 @@ def imarith_noiraf(operand1, op, operand2, result):
     assert os.path.exists(operand1)
     assert os.path.exists(operand2)
     assert op in ['+', '-']
+
+    ## Strip off the [0] part of the operand as we are assuming that we are
+    ## operating on the 0th FITS HDU.
+    if re.match('(\w+\.fits)\[0\]', operand1):
+        operand1 = operand1[:-3]
+    if re.match('(\w+\.fits)\[0\]', operand2):
+        operand2 = operand2[:-3]
 
     import operator
     operation = { "+": operator.add, "-": operator.sub }

--- a/scripts/AutoDriver.py
+++ b/scripts/AutoDriver.py
@@ -3,7 +3,8 @@
 import MOSFIRE
 from MOSFIRE import IO, Wavelength
 import os
-import pyfits as pf
+# import pyfits as pf
+from astropy.io import fits
 import time
 import sys
 import glob

--- a/scripts/AutoDriver.py
+++ b/scripts/AutoDriver.py
@@ -2,9 +2,10 @@
 
 import MOSFIRE
 from MOSFIRE import IO, Wavelength
+from MOSFIRE.IO import fname_to_path
 import os
 # import pyfits as pf
-from astropy.io import fits
+from astropy.io import fits as pf
 import time
 import sys
 import glob
@@ -32,7 +33,10 @@ class Driver:
         self.addLine("from MOSFIRE import Background, Combine, Detector, Flats, IO, Options, Rectify, Wavelength")
         self.addLine("from MOSFIRE.MosfireDrpLog import info, debug, warning, error")
         self.addLine("logger = logging.getLogger(__name__)")
-        self.addLine("import numpy as np, pylab as pl, pyfits as pf")
+#         self.addLine("import numpy as np, pylab as pl, pyfits as pf")
+        self.addLine("import numpy as np")
+        self.addLine("import pylab as pl")
+        self.addLine("from astropy.io import fits as pf")
         self.addLine("np.seterr(all='ignore')")
         self.addLine("flatops = Options.flat")
         self.addLine("waveops = Options.wavelength")

--- a/scripts/mospy_handle.py
+++ b/scripts/mospy_handle.py
@@ -9,7 +9,8 @@ import MOSFIRE
 import MOSFIRE.IO as IO
 import os
 import numpy as np
-import pyfits as pf
+# import pyfits as pf
+from astropy.io import fits
 import sys
 import glob
 


### PR DESCRIPTION
I've replaced the functionality in IO.imcombine and IO.imarith with equivalent functionality using either numpy or ccdproc.  

The pyRAF based functions are still in the code as imarith_iraf() and imcombine_iraf() alongside the new imarith_noiraf() and imcombine_noiraf().  To allow use of either, the IO.imarith() function just calls imarith_noiraf() and similarly for IO.imcombine().

I've also continued replacing pyfits with astropy.io.fits whoever I found it.

For the moment, the imcombine code does not handle any reject options other than "none", so "minmax", "sigclip", etc. will raise NotImplementedErrors. Propagating all this through just takes some bookkeeping, but I wanted to get comments and some testing in first before tackling this.  I don't have much experience with the MOSFIRE DRP, so my testing has been limited, but I did run this through successfully on one observation and compared it with a pyRAF based reduction and they came out identical.