### PR TITLE
Tweaks to Interactive Wavelength Fitting

### DIFF
--- a/MOSFIRE/Wavelength.py
+++ b/MOSFIRE/Wavelength.py
@@ -552,7 +552,7 @@ def check_wavelength_roi(maskname, band, skyfiles, arcfiles, LROI, options, no_c
     return LROI
 
 
-def fit_lambda_interactively(maskname, band, wavenames, options, neon=None, longslit=None,argon=None, extension=None, bypass=False,short_exp=False):
+def fit_lambda_interactively(maskname, band, wavenames, options, neon=None, longslit=None,argon=None, extension=None, noplots=False,short_exp=False):
     """Fit the one-dimensional wavelength solution to each science slit
     
     Args:
@@ -570,7 +570,7 @@ def fit_lambda_interactively(maskname, band, wavenames, options, neon=None, long
             row_position is the location to perform the interactive solution over. This
                 row should be clean of any contaminatring light
 
-        bypass: Bypass the manual fitting and run an autofit routine.
+        noplots: Bypass the manual fitting and run an autofit routine.
 
         """
 
@@ -614,10 +614,10 @@ def fit_lambda_interactively(maskname, band, wavenames, options, neon=None, long
     print("using line list")
     print(linelist)
     II = InteractiveSolution(fig, mfits, linelist, options, 1,
-        outfilename, solutions=solutions, bypass=bypass, starting_pos=starting_pos)
+        outfilename, solutions=solutions, noplots=noplots, starting_pos=starting_pos)
     info( "Waiting")
 
-    if bypass is False:
+    if noplots is False:
         pl.ioff()
         pl.show()
         #pl.draw()
@@ -1626,7 +1626,7 @@ class InteractiveSolution:
     first_time = True
 
     def __init__(self, fig, mfits, linelist, options, slitno, outfilename, 
-            solutions=None,bypass=False, starting_pos=None):
+            solutions=None, noplots=False, starting_pos=None):
         self.header = mfits[0]
         self.data = mfits[1]
         self.bs = mfits[2]
@@ -1636,7 +1636,7 @@ class InteractiveSolution:
         self.fig = fig
         self.outfilename = outfilename
         self.starting_pos = starting_pos
-        self.bypass = bypass
+        self.noplots = noplots
         self.pix = np.arange(2048)
         band = self.header["filter"].rstrip()
         self.xrng = Filters.hpp[band][:]
@@ -1650,7 +1650,7 @@ class InteractiveSolution:
         else:
             self.solutions = solutions
 
-        if self.bypass:
+        if self.noplots:
             self.setup()
             self.fit_event(0,0)
             #self.nextobject(0,0)  ### the call to next object is built-in in fit_event
@@ -1736,17 +1736,17 @@ class InteractiveSolution:
 
         self.ll = CV.chebval(self.pix, self.cfit)
 
-        if self.bypass:
+        if self.noplots:
             pass
         else:
             info("Launching graphics display.    ")
             self.redraw()
 
-    def toggle_bypass(self,x,y):
+    def toggle_noplots(self,x,y):
         info("############ NON INTERACTIVE MODE ENABLED ###########")
         info("# From now on, the fit will proceed automatically   #")
         info("#####################################################")
-        self.bypass = True
+        self.noplots = True
         self.quit(0,0)
         self.nextobject(0,0)
         
@@ -1889,7 +1889,7 @@ class InteractiveSolution:
         if self.slitno > len(self.bs.ssl): 
             self.done = True
             self.slitno -= 1
-            if self.bypass is False:
+            if self.noplots is False:
                 self.draw_done()
 
         info("Saving to: "+str(self.outfilename))
@@ -1951,7 +1951,7 @@ class InteractiveSolution:
 
         # Calculate current std error
         error = np.std(deltas[np.isfinite(deltas)])
-        if self.sigma_clip is True or self.bypass:
+        if self.sigma_clip is True or self.noplots:
             # prepare a sigma tolerance (reject values of deltas > tolerance * sigma)
             tolerance = 3
             # if the std error is > 0.10, iteratively reject lines
@@ -1996,7 +1996,7 @@ class InteractiveSolution:
 
         info('Stored: '+str(self.solutions[self.slitno-1]['slitno']))
 
-        if self.bypass is False:
+        if self.noplots is False:
             self.redraw()
         else:
             self.nextobject(0,0)
@@ -2010,7 +2010,7 @@ class InteractiveSolution:
 
         actions_mouseless = {".": self.fastforward, "n": self.nextobject, "p":
                 self.prevobject, "q": self.quit, "r": self.reset, "f":
-                self.fit_event, "k": self.toggle_sigma_clip, "\\": self.fit_event, "b": self.toggle_bypass}
+                self.fit_event, "k": self.toggle_sigma_clip, "\\": self.fit_event, "b": self.toggle_noplots}
 
         actions = { "c": self.shift, "d": self.drop_point,
                 "z": self.zoom, "x": self.unzoom, "s": self.savefig}

--- a/MOSFIRE/Wavelength.py
+++ b/MOSFIRE/Wavelength.py
@@ -60,12 +60,11 @@ try:
     from astropy.io import fits as pf
 except:
     import pyfits as pf
-from matplotlib import pyplot as pl
 
 from scipy.interpolate import interp1d
 from scipy import signal 
 from scipy import optimize
-from matplotlib.widgets import Button
+# from matplotlib.widgets import Button
 from numpy.polynomial import chebyshev as CV
 
 
@@ -493,6 +492,7 @@ def check_wavelength_roi(maskname, band, skyfiles, arcfiles, LROI, options, no_c
     '''The purpose of this function is to help the user selection a wavelength
         range of interest over which to normalize the arcs versus sky solutions.
         '''
+    from matplotlib import pyplot as pl
     skyfiles = IO.list_file_to_strings(skyfiles)
     skyfilename = filelist_to_path(skyfiles, band, maskname, options)
     fn = "lambda_center_coeffs_{0}.npy".format(skyfilename.rstrip(".fits"))
@@ -1663,9 +1663,11 @@ class InteractiveSolution:
             self.setup()
             self.fit_event(0,0)
 
-        # follow line prevents window from going full screen when the
-        # 'f'it button is pressed.
-        pl.rcParams['keymap.fullscreen'] = ''
+        if not noplots:
+            from matplotlib import pyplot as pl
+            # follow line prevents window from going full screen when the
+            # 'f'it button is pressed.
+            pl.rcParams['keymap.fullscreen'] = ''
 
     
     def setup(self):

--- a/MOSFIRE/Wavelength.py
+++ b/MOSFIRE/Wavelength.py
@@ -1912,8 +1912,8 @@ class InteractiveSolution:
 
     def quit(self, x, y):
         """Quit and save the results """
-        info("Closing figure")
         if self.fig is not None:
+            info("Closing figure")
             pl.close(self.fig)
 
 

--- a/MOSFIRE/Wavelength.py
+++ b/MOSFIRE/Wavelength.py
@@ -67,6 +67,7 @@ from scipy import optimize
 # from matplotlib.widgets import Button
 from numpy.polynomial import chebyshev as CV
 
+from matplotlib import pyplot as pl
 
 from MOSFIRE import CSU, Fit, IO, Options, Filters, Detector
 from MosfireDrpLog import debug, info, warning, error
@@ -492,7 +493,6 @@ def check_wavelength_roi(maskname, band, skyfiles, arcfiles, LROI, options, no_c
     '''The purpose of this function is to help the user selection a wavelength
         range of interest over which to normalize the arcs versus sky solutions.
         '''
-    from matplotlib import pyplot as pl
     skyfiles = IO.list_file_to_strings(skyfiles)
     skyfilename = filelist_to_path(skyfiles, band, maskname, options)
     fn = "lambda_center_coeffs_{0}.npy".format(skyfilename.rstrip(".fits"))
@@ -604,7 +604,10 @@ def fit_lambda_interactively(maskname, band, wavenames, options, neon=None, long
     tock = time.time()
     
     outfilename = fn
-    fig = pl.figure(1,figsize=(16,8))
+    if noplots is False:
+        fig = pl.figure(1,figsize=(16,8))
+    else:
+        fig = None
     info("Started interactive solution")
     if longslit is not None and longslit['mode'] is "longslit":
         starting_pos = longslit["row_position"]
@@ -1659,15 +1662,12 @@ class InteractiveSolution:
                 self.fit_event(0,0)
                 self.nextobject(0,0)
         else:
-            self.cid = self.fig.canvas.mpl_connect('key_press_event', self)
-            self.setup()
-            self.fit_event(0,0)
-
-        if not noplots:
-            from matplotlib import pyplot as pl
             # follow line prevents window from going full screen when the
             # 'f'it button is pressed.
             pl.rcParams['keymap.fullscreen'] = ''
+            self.cid = self.fig.canvas.mpl_connect('key_press_event', self)
+            self.setup()
+            self.fit_event(0,0)
 
     
     def setup(self):
@@ -1913,7 +1913,8 @@ class InteractiveSolution:
     def quit(self, x, y):
         """Quit and save the results """
         info("Closing figure")
-        pl.close(self.fig)
+        if self.fig is not None:
+            pl.close(self.fig)
 
 
     def reset(self, x, y):

--- a/apps/AutoDriver.py
+++ b/apps/AutoDriver.py
@@ -49,9 +49,9 @@ class Driver:
             self.addLine(obsfile)
         self.addLine("")
 
-    def printBypass(self,bypass=False):
-        self.addLine("#Set bypass to True to autofit wavelenth solution instead of manually fitting.")
-        self.addLine("bypassflag="+str(bypass))
+    def printnoplots(self,noplots=False):
+        self.addLine("#Set noplots to True to autofit wavelenth solution instead of manually fitting.")
+        self.addLine("noplotsflag="+str(noplots))
 
     def printMaskAndBand(self):
         offsetfile = self.offsetFiles[0]
@@ -134,7 +134,7 @@ class Driver:
             if self.useNeon:
                 self.addLine("Wavelength.imcombine('Ne.txt', maskname, band, waveops)")
 
-            self.addLine("Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops"+addLongSlit+", bypass=bypassflag)")
+            self.addLine("Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops"+addLongSlit+", noplots=noplotsflag)")
 
             if self.useArgon:
                 self.addLine("Wavelength.apply_interactive(maskname, band, waveops, apply=obsfiles, to='Ar.txt', argon=True)")
@@ -189,7 +189,7 @@ class Driver:
             if calibWith:
                 # we have either Argon, or Neon, or both, so we can use arcs for the reduction
                 self.addLine("Wavelength.imcombine("+str(calibWith)+", maskname, band, waveops)")
-                self.addLine("Wavelength.fit_lambda_interactively(maskname, band, "+str(calibWith)+",waveops,longslit=longslit, "+str(calibWith)+"=True, bypass=bypassflag)")
+                self.addLine("Wavelength.fit_lambda_interactively(maskname, band, "+str(calibWith)+",waveops,longslit=longslit, "+str(calibWith)+"=True, noplots=noplotsflag)")
                 self.addLine("Wavelength.fit_lambda(maskname, band, "+str(calibWith)+","+str(calibWith)+",waveops,longslit=longslit)")
                 self.addLine("Wavelength.apply_lambda_simple(maskname, band, "+str(calibWith)+", waveops, longslit=longslit, smooth=True)")            
                 self.waveName = "lambda_solution_"+str(Wavelength.filelist_to_wavename(waveFiles, self.band, self.maskName,""))
@@ -203,7 +203,7 @@ class Driver:
                 print "#####################################################################################################" 
                 self.addLine("obsfiles = obsfiles_posAnarrow + obsfiles_posCnarrow")
                 self.addLine("Wavelength.imcombine(obsfiles, maskname, band, waveops)")
-                self.addLine("Wavelength.fit_lambda_interactively(maskname, band, obsfiles ,waveops,longslit=longslit, bypass=bypassflag)")
+                self.addLine("Wavelength.fit_lambda_interactively(maskname, band, obsfiles ,waveops,longslit=longslit, noplots=noplotsflag)")
                 self.addLine("Wavelength.fit_lambda(maskname, band, obsfiles,obsfiles ,waveops,longslit=longslit)")
                 self.addLine("Wavelength.apply_lambda_simple(maskname, band, obsfiles, waveops, longslit=longslit, smooth=True)")            
                 files = IO.list_file_to_strings(self.offsetFiles)
@@ -383,17 +383,17 @@ def SetupFiles(target=None, offsets=None, type=None):
 
 
 
-#set bypass variable
+#set noplots variable
 if len(sys.argv) > 3:
     print "Usage: mospy AutoDriver [True|False]"
     sys.exit()
 
-bypassval=False
+noplotsval=False
 if len(sys.argv) == 3: 
     if str(sys.argv[2]) in ("t", "T" "true", "True"):
-        bypassval=True
+        noplotsval=True
     elif str(sys.argv[2]) in ("f", "F" "false", "False"):
-        bypassval=False
+        noplotsval=False
     else:
         print "Usage: mospy AutoDriver [True|False]"
         sys.exit()
@@ -410,7 +410,7 @@ if 'slitmask' in targets_and_offsets:
     obsLines,obsFiles,specphot = SetupFiles('slitmask',targets_and_offsets['slitmask'],type)   
     mydriver.addOffsetFiles(obsFiles)
     mydriver.printMaskAndBand()
-    mydriver.printBypass(bypass=bypassval)
+    mydriver.printnoplots(noplots=noplotsval)
     mydriver.printObsfiles(obsLines)
     mydriver.printFlat()
     mydriver.printWavelengthFit()
@@ -432,7 +432,7 @@ elif type is 'long2pos' or type is 'longslit':
         mydriver.printHeader()
         mydriver.addOffsetFiles(obsFiles)
         mydriver.printMaskAndBand()
-        mydriver.printBypass(bypass=bypassval)
+        mydriver.printnoplots(noplots=noplotsval)
         mydriver.printObsfiles(obsLines)
         mydriver.addLongslit()        
         mydriver.printFlat()

--- a/apps/AutoDriver.py
+++ b/apps/AutoDriver.py
@@ -49,9 +49,9 @@ class Driver:
             self.addLine(obsfile)
         self.addLine("")
 
-    def printnoplots(self,noplots=False):
-        self.addLine("#Set noplots to True to autofit wavelenth solution instead of manually fitting.")
-        self.addLine("noplotsflag="+str(noplots))
+    def printnoninteractive(self,noninteractive=False):
+        self.addLine("#Set noninteractive to True to autofit wavelenth solution instead of manually fitting.")
+        self.addLine("noninteractiveflag="+str(noninteractive))
 
     def printMaskAndBand(self):
         offsetfile = self.offsetFiles[0]
@@ -134,7 +134,7 @@ class Driver:
             if self.useNeon:
                 self.addLine("Wavelength.imcombine('Ne.txt', maskname, band, waveops)")
 
-            self.addLine("Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops"+addLongSlit+", noplots=noplotsflag)")
+            self.addLine("Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops"+addLongSlit+", noninteractive=noninteractiveflag)")
 
             if self.useArgon:
                 self.addLine("Wavelength.apply_interactive(maskname, band, waveops, apply=obsfiles, to='Ar.txt', argon=True)")
@@ -189,7 +189,7 @@ class Driver:
             if calibWith:
                 # we have either Argon, or Neon, or both, so we can use arcs for the reduction
                 self.addLine("Wavelength.imcombine("+str(calibWith)+", maskname, band, waveops)")
-                self.addLine("Wavelength.fit_lambda_interactively(maskname, band, "+str(calibWith)+",waveops,longslit=longslit, "+str(calibWith)+"=True, noplots=noplotsflag)")
+                self.addLine("Wavelength.fit_lambda_interactively(maskname, band, "+str(calibWith)+",waveops,longslit=longslit, "+str(calibWith)+"=True, noninteractive=noninteractiveflag)")
                 self.addLine("Wavelength.fit_lambda(maskname, band, "+str(calibWith)+","+str(calibWith)+",waveops,longslit=longslit)")
                 self.addLine("Wavelength.apply_lambda_simple(maskname, band, "+str(calibWith)+", waveops, longslit=longslit, smooth=True)")            
                 self.waveName = "lambda_solution_"+str(Wavelength.filelist_to_wavename(waveFiles, self.band, self.maskName,""))
@@ -203,7 +203,7 @@ class Driver:
                 print "#####################################################################################################" 
                 self.addLine("obsfiles = obsfiles_posAnarrow + obsfiles_posCnarrow")
                 self.addLine("Wavelength.imcombine(obsfiles, maskname, band, waveops)")
-                self.addLine("Wavelength.fit_lambda_interactively(maskname, band, obsfiles ,waveops,longslit=longslit, noplots=noplotsflag)")
+                self.addLine("Wavelength.fit_lambda_interactively(maskname, band, obsfiles ,waveops,longslit=longslit, noninteractive=noninteractiveflag)")
                 self.addLine("Wavelength.fit_lambda(maskname, band, obsfiles,obsfiles ,waveops,longslit=longslit)")
                 self.addLine("Wavelength.apply_lambda_simple(maskname, band, obsfiles, waveops, longslit=longslit, smooth=True)")            
                 files = IO.list_file_to_strings(self.offsetFiles)
@@ -383,17 +383,17 @@ def SetupFiles(target=None, offsets=None, type=None):
 
 
 
-#set noplots variable
+#set noninteractive variable
 if len(sys.argv) > 3:
     print "Usage: mospy AutoDriver [True|False]"
     sys.exit()
 
-noplotsval=False
+noninteractiveval=False
 if len(sys.argv) == 3: 
     if str(sys.argv[2]) in ("t", "T" "true", "True"):
-        noplotsval=True
+        noninteractiveval=True
     elif str(sys.argv[2]) in ("f", "F" "false", "False"):
-        noplotsval=False
+        noninteractiveval=False
     else:
         print "Usage: mospy AutoDriver [True|False]"
         sys.exit()
@@ -410,7 +410,7 @@ if 'slitmask' in targets_and_offsets:
     obsLines,obsFiles,specphot = SetupFiles('slitmask',targets_and_offsets['slitmask'],type)   
     mydriver.addOffsetFiles(obsFiles)
     mydriver.printMaskAndBand()
-    mydriver.printnoplots(noplots=noplotsval)
+    mydriver.printnoninteractive(noninteractive=noninteractiveval)
     mydriver.printObsfiles(obsLines)
     mydriver.printFlat()
     mydriver.printWavelengthFit()
@@ -432,7 +432,7 @@ elif type is 'long2pos' or type is 'longslit':
         mydriver.printHeader()
         mydriver.addOffsetFiles(obsFiles)
         mydriver.printMaskAndBand()
-        mydriver.printnoplots(noplots=noplotsval)
+        mydriver.printnoninteractive(noninteractive=noninteractiveval)
         mydriver.printObsfiles(obsLines)
         mydriver.addLongslit()        
         mydriver.printFlat()

--- a/drivers/Driver.py
+++ b/drivers/Driver.py
@@ -19,14 +19,14 @@ waveops = Options.wavelength
 maskname = 'maskname'
 band = 'band'
 
-#Set bypass to True to autofit wavelenth solution instead of manually fitting.
-bypassflag=False
+#Set noplots to True to autofit wavelenth solution instead of manually fitting.
+noplotsflag=False
 obsfiles=['Offset_1.25.txt','Offset_-1.25.txt']
 
 Flats.handle_flats('Flat.txt', maskname, band, flatops)
 
 Wavelength.imcombine(obsfiles, maskname, band, waveops)
-Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops, bypass=bypassflag)
+Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops, noplots=noplotsflag)
 Wavelength.fit_lambda(maskname, band, obsfiles, obsfiles,waveops)
 Wavelength.apply_lambda_simple(maskname, band, obsfiles, waveops)
 

--- a/drivers/Driver.py
+++ b/drivers/Driver.py
@@ -19,14 +19,14 @@ waveops = Options.wavelength
 maskname = 'maskname'
 band = 'band'
 
-#Set noplots to True to autofit wavelenth solution instead of manually fitting.
-noplotsflag=False
+#Set noninteractive to True to autofit wavelenth solution instead of manually fitting.
+noninteractiveflag=False
 obsfiles=['Offset_1.25.txt','Offset_-1.25.txt']
 
 Flats.handle_flats('Flat.txt', maskname, band, flatops)
 
 Wavelength.imcombine(obsfiles, maskname, band, waveops)
-Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops, noplots=noplotsflag)
+Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops, noninteractive=noninteractiveflag)
 Wavelength.fit_lambda(maskname, band, obsfiles, obsfiles,waveops)
 Wavelength.apply_lambda_simple(maskname, band, obsfiles, waveops)
 

--- a/drivers/K_driver.py
+++ b/drivers/K_driver.py
@@ -19,8 +19,8 @@ waveops = Options.wavelength
 maskname = 'maskname'
 band = 'band'
 
-#Set noplots to True to autofit wavelenth solution instead of manually fitting.
-noplotsflag=False
+#Set noninteractive to True to autofit wavelenth solution instead of manually fitting.
+noninteractiveflag=False
 obsfiles=['Offset_1.25.txt','Offset_-1.25.txt']
 
 Flats.handle_flats('Flat.txt', maskname, band, flatops,lampOffList='FlatThermal.txt')
@@ -30,7 +30,7 @@ Wavelength.imcombine(obsfiles, maskname, band, waveops)
 Wavelength.imcombine('Ar.txt', maskname, band, waveops)
 # if you have Ne
 Wavelength.imcombine('Ne.txt', maskname, band, waveops)
-Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops, noplots=noplotsflag)
+Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops, noninteractive=noninteractiveflag)
 
 Wavelength.apply_interactive(maskname, band, waveops, apply=obsfiles, to='Ar.txt', argon=True)
 Wavelength.apply_interactive(maskname, band, waveops, apply=obsfiles, to='Ne.txt', neon=True)

--- a/drivers/K_driver.py
+++ b/drivers/K_driver.py
@@ -19,8 +19,8 @@ waveops = Options.wavelength
 maskname = 'maskname'
 band = 'band'
 
-#Set bypass to True to autofit wavelenth solution instead of manually fitting.
-bypassflag=False
+#Set noplots to True to autofit wavelenth solution instead of manually fitting.
+noplotsflag=False
 obsfiles=['Offset_1.25.txt','Offset_-1.25.txt']
 
 Flats.handle_flats('Flat.txt', maskname, band, flatops,lampOffList='FlatThermal.txt')
@@ -30,7 +30,7 @@ Wavelength.imcombine(obsfiles, maskname, band, waveops)
 Wavelength.imcombine('Ar.txt', maskname, band, waveops)
 # if you have Ne
 Wavelength.imcombine('Ne.txt', maskname, band, waveops)
-Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops, bypass=bypassflag)
+Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops, noplots=noplotsflag)
 
 Wavelength.apply_interactive(maskname, band, waveops, apply=obsfiles, to='Ar.txt', argon=True)
 Wavelength.apply_interactive(maskname, band, waveops, apply=obsfiles, to='Ne.txt', neon=True)

--- a/drivers/Long2pos.py
+++ b/drivers/Long2pos.py
@@ -23,8 +23,8 @@ waveops = Options.wavelength
 maskname = 'long2pos_specphot (align)'
 band = 'H'
 
-#Set noplots to True to autofit wavelenth solution instead of manually fitting.
-noplotsflag=False
+#Set noninteractive to True to autofit wavelenth solution instead of manually fitting.
+noninteractiveflag=False
 
 # these are the narrow slits
 obsfiles_posCnarrow = ['Offset_-21_HIP85871_7.25_PosC.txt', 'Offset_-7_HIP85871_7.25_PosC.txt']
@@ -49,7 +49,7 @@ Flats.handle_flats('Flat.txt', maskname, band, flatops,longslit=longslit)
 # replace this with neon=['Ne.txt'] if you prefer to use Ne, and edit the following lines accordingly
 argon = ['Ar.txt']
 Wavelength.imcombine(argon, maskname, band, waveops)
-Wavelength.fit_lambda_interactively(maskname, band, argon,waveops,longslit=longslit, argon=True, noplots=noplotsflag)
+Wavelength.fit_lambda_interactively(maskname, band, argon,waveops,longslit=longslit, argon=True, noninteractive=noninteractiveflag)
 Wavelength.fit_lambda(maskname, band, argon,argon,waveops,longslit=longslit)
 Wavelength.apply_lambda_simple(maskname, band, argon, waveops, longslit=longslit, smooth=True)
 

--- a/drivers/Long2pos.py
+++ b/drivers/Long2pos.py
@@ -23,8 +23,8 @@ waveops = Options.wavelength
 maskname = 'long2pos_specphot (align)'
 band = 'H'
 
-#Set bypass to True to autofit wavelenth solution instead of manually fitting.
-bypassflag=False
+#Set noplots to True to autofit wavelenth solution instead of manually fitting.
+noplotsflag=False
 
 # these are the narrow slits
 obsfiles_posCnarrow = ['Offset_-21_HIP85871_7.25_PosC.txt', 'Offset_-7_HIP85871_7.25_PosC.txt']
@@ -49,7 +49,7 @@ Flats.handle_flats('Flat.txt', maskname, band, flatops,longslit=longslit)
 # replace this with neon=['Ne.txt'] if you prefer to use Ne, and edit the following lines accordingly
 argon = ['Ar.txt']
 Wavelength.imcombine(argon, maskname, band, waveops)
-Wavelength.fit_lambda_interactively(maskname, band, argon,waveops,longslit=longslit, argon=True, bypass=bypassflag)
+Wavelength.fit_lambda_interactively(maskname, band, argon,waveops,longslit=longslit, argon=True, noplots=noplotsflag)
 Wavelength.fit_lambda(maskname, band, argon,argon,waveops,longslit=longslit)
 Wavelength.apply_lambda_simple(maskname, band, argon, waveops, longslit=longslit, smooth=True)
 

--- a/drivers/Longslit_driver.py
+++ b/drivers/Longslit_driver.py
@@ -19,8 +19,8 @@ waveops = Options.wavelength
 maskname = 'LONGSLIT-3x0.7'
 band = 'H'
 
-#Set bypass to True to autofit wavelenth solution instead of manually fitting.
-bypassflag=False
+#Set noplots to True to autofit wavelenth solution instead of manually fitting.
+noplotsflag=False
 # modify the target name to match your observations
 obsfiles=['Offset_5_HIP17971.txt','Offset_-5_HIP17971.txt']
 target="HIP17971"
@@ -32,7 +32,7 @@ longslit = {'yrange':[968,1100],'row_position':1034,'mode':'longslit'}
 Flats.handle_flats('Flat.txt', maskname, band, flatops,longslit=longslit)
 
 Wavelength.imcombine(obsfiles, maskname, band, waveops)
-Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops,longslit=longslit, bypass=bypassflag)
+Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops,longslit=longslit, noplots=noplotsflag)
 Wavelength.fit_lambda(maskname, band, obsfiles, obsfiles,waveops,longslit=longslit)
 Wavelength.apply_lambda_simple(maskname, band, obsfiles, waveops,longslit=longslit)
 

--- a/drivers/Longslit_driver.py
+++ b/drivers/Longslit_driver.py
@@ -19,8 +19,8 @@ waveops = Options.wavelength
 maskname = 'LONGSLIT-3x0.7'
 band = 'H'
 
-#Set noplots to True to autofit wavelenth solution instead of manually fitting.
-noplotsflag=False
+#Set noninteractive to True to autofit wavelenth solution instead of manually fitting.
+noninteractiveflag=False
 # modify the target name to match your observations
 obsfiles=['Offset_5_HIP17971.txt','Offset_-5_HIP17971.txt']
 target="HIP17971"
@@ -32,7 +32,7 @@ longslit = {'yrange':[968,1100],'row_position':1034,'mode':'longslit'}
 Flats.handle_flats('Flat.txt', maskname, band, flatops,longslit=longslit)
 
 Wavelength.imcombine(obsfiles, maskname, band, waveops)
-Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops,longslit=longslit, noplots=noplotsflag)
+Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops,longslit=longslit, noninteractive=noninteractiveflag)
 Wavelength.fit_lambda(maskname, band, obsfiles, obsfiles,waveops,longslit=longslit)
 Wavelength.apply_lambda_simple(maskname, band, obsfiles, waveops,longslit=longslit)
 

--- a/scripts/AutoDriver.py
+++ b/scripts/AutoDriver.py
@@ -55,9 +55,9 @@ class Driver:
             self.addLine(obsfile)
         self.addLine("")
 
-    def printBypass(self,bypass=False):
-        self.addLine("#Set bypass to True to autofit wavelenth solution instead of manually fitting.")
-        self.addLine("bypassflag="+str(bypass))
+    def printnoplots(self,noplots=False):
+        self.addLine("#Set noplots to True to autofit wavelenth solution instead of manually fitting.")
+        self.addLine("noplotsflag="+str(noplots))
 
     def printMaskAndBand(self):
         offsetfile = self.offsetFiles[0]
@@ -140,7 +140,7 @@ class Driver:
             if self.useNeon:
                 self.addLine("Wavelength.imcombine('Ne.txt', maskname, band, waveops)")
 
-            self.addLine("Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops"+addLongSlit+", bypass=bypassflag)")
+            self.addLine("Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops"+addLongSlit+", noplots=noplotsflag)")
 
             if self.useArgon:
                 self.addLine("Wavelength.apply_interactive(maskname, band, waveops, apply=obsfiles, to='Ar.txt', argon=True)")
@@ -195,7 +195,7 @@ class Driver:
             if calibWith:
                 # we have either Argon, or Neon, or both, so we can use arcs for the reduction
                 self.addLine("Wavelength.imcombine("+str(calibWith)+", maskname, band, waveops)")
-                self.addLine("Wavelength.fit_lambda_interactively(maskname, band, "+str(calibWith)+",waveops,longslit=longslit, "+str(calibWith)+"=True, bypass=bypassflag)")
+                self.addLine("Wavelength.fit_lambda_interactively(maskname, band, "+str(calibWith)+",waveops,longslit=longslit, "+str(calibWith)+"=True, noplots=noplotsflag)")
                 self.addLine("Wavelength.fit_lambda(maskname, band, "+str(calibWith)+","+str(calibWith)+",waveops,longslit=longslit)")
                 self.addLine("Wavelength.apply_lambda_simple(maskname, band, "+str(calibWith)+", waveops, longslit=longslit, smooth=True)")            
                 self.waveName = "lambda_solution_"+str(Wavelength.filelist_to_wavename(waveFiles, self.band, self.maskName,""))
@@ -209,7 +209,7 @@ class Driver:
                 print "#####################################################################################################" 
                 self.addLine("obsfiles = obsfiles_posAnarrow + obsfiles_posCnarrow")
                 self.addLine("Wavelength.imcombine(obsfiles, maskname, band, waveops)")
-                self.addLine("Wavelength.fit_lambda_interactively(maskname, band, obsfiles ,waveops,longslit=longslit, bypass=bypassflag)")
+                self.addLine("Wavelength.fit_lambda_interactively(maskname, band, obsfiles ,waveops,longslit=longslit, noplots=noplotsflag)")
                 self.addLine("Wavelength.fit_lambda(maskname, band, obsfiles,obsfiles ,waveops,longslit=longslit)")
                 self.addLine("Wavelength.apply_lambda_simple(maskname, band, obsfiles, waveops, longslit=longslit, smooth=True)")            
                 files = IO.list_file_to_strings(self.offsetFiles)
@@ -382,17 +382,17 @@ def SetupFiles(target=None, offsets=None, type=None):
 
 
 
-#set bypass variable
+#set noplots variable
 if len(sys.argv) > 3:
     print "Usage: mospy AutoDriver [True|False]"
     sys.exit()
 
-bypassval=False
+noplotsval=False
 if len(sys.argv) == 3: 
     if str(sys.argv[2]) in ("t", "T" "true", "True"):
-        bypassval=True
+        noplotsval=True
     elif str(sys.argv[2]) in ("f", "F" "false", "False"):
-        bypassval=False
+        noplotsval=False
     else:
         print "Usage: mospy AutoDriver [True|False]"
         sys.exit()
@@ -409,7 +409,7 @@ if 'slitmask' in targets_and_offsets:
     obsLines,obsFiles,specphot = SetupFiles('slitmask',targets_and_offsets['slitmask'],type)   
     mydriver.addOffsetFiles(obsFiles)
     mydriver.printMaskAndBand()
-    mydriver.printBypass(bypass=bypassval)
+    mydriver.printnoplots(noplots=noplotsval)
     mydriver.printObsfiles(obsLines)
     mydriver.printFlat()
     mydriver.printWavelengthFit()
@@ -431,7 +431,7 @@ elif type is 'long2pos' or type is 'longslit':
         mydriver.printHeader()
         mydriver.addOffsetFiles(obsFiles)
         mydriver.printMaskAndBand()
-        mydriver.printBypass(bypass=bypassval)
+        mydriver.printnoplots(noplots=noplotsval)
         mydriver.printObsfiles(obsLines)
         mydriver.addLongslit()        
         mydriver.printFlat()

--- a/scripts/AutoDriver.py
+++ b/scripts/AutoDriver.py
@@ -55,9 +55,9 @@ class Driver:
             self.addLine(obsfile)
         self.addLine("")
 
-    def printnoplots(self,noplots=False):
-        self.addLine("#Set noplots to True to autofit wavelenth solution instead of manually fitting.")
-        self.addLine("noplotsflag="+str(noplots))
+    def printnoninteractive(self,noninteractive=False):
+        self.addLine("#Set noninteractive to True to autofit wavelenth solution instead of manually fitting.")
+        self.addLine("noninteractiveflag="+str(noninteractive))
 
     def printMaskAndBand(self):
         offsetfile = self.offsetFiles[0]
@@ -140,7 +140,7 @@ class Driver:
             if self.useNeon:
                 self.addLine("Wavelength.imcombine('Ne.txt', maskname, band, waveops)")
 
-            self.addLine("Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops"+addLongSlit+", noplots=noplotsflag)")
+            self.addLine("Wavelength.fit_lambda_interactively(maskname, band, obsfiles,waveops"+addLongSlit+", noninteractive=noninteractiveflag)")
 
             if self.useArgon:
                 self.addLine("Wavelength.apply_interactive(maskname, band, waveops, apply=obsfiles, to='Ar.txt', argon=True)")
@@ -195,7 +195,7 @@ class Driver:
             if calibWith:
                 # we have either Argon, or Neon, or both, so we can use arcs for the reduction
                 self.addLine("Wavelength.imcombine("+str(calibWith)+", maskname, band, waveops)")
-                self.addLine("Wavelength.fit_lambda_interactively(maskname, band, "+str(calibWith)+",waveops,longslit=longslit, "+str(calibWith)+"=True, noplots=noplotsflag)")
+                self.addLine("Wavelength.fit_lambda_interactively(maskname, band, "+str(calibWith)+",waveops,longslit=longslit, "+str(calibWith)+"=True, noninteractive=noninteractiveflag)")
                 self.addLine("Wavelength.fit_lambda(maskname, band, "+str(calibWith)+","+str(calibWith)+",waveops,longslit=longslit)")
                 self.addLine("Wavelength.apply_lambda_simple(maskname, band, "+str(calibWith)+", waveops, longslit=longslit, smooth=True)")            
                 self.waveName = "lambda_solution_"+str(Wavelength.filelist_to_wavename(waveFiles, self.band, self.maskName,""))
@@ -209,7 +209,7 @@ class Driver:
                 print "#####################################################################################################" 
                 self.addLine("obsfiles = obsfiles_posAnarrow + obsfiles_posCnarrow")
                 self.addLine("Wavelength.imcombine(obsfiles, maskname, band, waveops)")
-                self.addLine("Wavelength.fit_lambda_interactively(maskname, band, obsfiles ,waveops,longslit=longslit, noplots=noplotsflag)")
+                self.addLine("Wavelength.fit_lambda_interactively(maskname, band, obsfiles ,waveops,longslit=longslit, noninteractive=noninteractiveflag)")
                 self.addLine("Wavelength.fit_lambda(maskname, band, obsfiles,obsfiles ,waveops,longslit=longslit)")
                 self.addLine("Wavelength.apply_lambda_simple(maskname, band, obsfiles, waveops, longslit=longslit, smooth=True)")            
                 files = IO.list_file_to_strings(self.offsetFiles)
@@ -382,17 +382,17 @@ def SetupFiles(target=None, offsets=None, type=None):
 
 
 
-#set noplots variable
+#set noninteractive variable
 if len(sys.argv) > 3:
     print "Usage: mospy AutoDriver [True|False]"
     sys.exit()
 
-noplotsval=False
+noninteractiveval=False
 if len(sys.argv) == 3: 
     if str(sys.argv[2]) in ("t", "T" "true", "True"):
-        noplotsval=True
+        noninteractiveval=True
     elif str(sys.argv[2]) in ("f", "F" "false", "False"):
-        noplotsval=False
+        noninteractiveval=False
     else:
         print "Usage: mospy AutoDriver [True|False]"
         sys.exit()
@@ -409,7 +409,7 @@ if 'slitmask' in targets_and_offsets:
     obsLines,obsFiles,specphot = SetupFiles('slitmask',targets_and_offsets['slitmask'],type)   
     mydriver.addOffsetFiles(obsFiles)
     mydriver.printMaskAndBand()
-    mydriver.printnoplots(noplots=noplotsval)
+    mydriver.printnoninteractive(noninteractive=noninteractiveval)
     mydriver.printObsfiles(obsLines)
     mydriver.printFlat()
     mydriver.printWavelengthFit()
@@ -431,7 +431,7 @@ elif type is 'long2pos' or type is 'longslit':
         mydriver.printHeader()
         mydriver.addOffsetFiles(obsFiles)
         mydriver.printMaskAndBand()
-        mydriver.printnoplots(noplots=noplotsval)
+        mydriver.printnoninteractive(noninteractive=noninteractiveval)
         mydriver.printObsfiles(obsLines)
         mydriver.addLongslit()        
         mydriver.printFlat()


### PR DESCRIPTION
I think the "bypass" flag to skip the wavelength fitting is too vague a term.  Users might not understand what is being bypassed, so I made this branch (from my imcombine) which replaces bypass with "noplot".  I also tweaked the code so that no figures are instantiated if noplot is True which will help if no X windows session is available (such as when SSH'd in to a server without X forwarding).

This is a UI change, so we should decide whether we want to do this.  This particular PR is just a suggestion for the terminology.  As an alternative, we might make plot or noplot a flag to be set when calling AutoDriver (rather than editing Driver.py directly), but I haven't tried to implement that.