### PR TITLE
Fix TypeError when arrays are indexed with non-integer value

### DIFF
--- a/MOSFIRE/Flats.py
+++ b/MOSFIRE/Flats.py
@@ -375,7 +375,7 @@ def find_edge_pair(data, y, roi_width, edgeThreshold=450):
     '''
 
     def select_roi(data, roi_width):
-        v = data[y-roi_width:y+roi_width, xp-2:xp+2]
+        v = data[int(y-roi_width):int(y+roi_width), int(xp)-2:int(xp)+2]
         v = np.median(v, axis=1) # Axis = 1 is spatial direction
 
         return v

--- a/MOSFIRE/Flats.py
+++ b/MOSFIRE/Flats.py
@@ -791,7 +791,7 @@ def find_and_fit_edges(data, header, bs, options,edgeThreshold=450):
     xposs_top_this = np.arange(10,2000,100)
     yposs_top_this = topfun(xposs_top_this)
 
-    initial_edges = np.array([2034])
+    initial_edges = np.array([2034], dtype=np.int)
     edge = 2034
 
     # build an array of values containing the lower edge of the slits
@@ -799,14 +799,14 @@ def find_and_fit_edges(data, header, bs, options,edgeThreshold=450):
     for target in xrange(len(ssl)):        
     # target is the slit number
         edge -= DY * numslits[target]
-        initial_edges=np.append(initial_edges,edge)
+        initial_edges=np.append(initial_edges,int(edge))
 
     # collapse the 2d flat along the walenegth axis to build a spatial profile of the slits
     vertical_profile = np.mean(data, axis=1)
 
     # build an array containing the spatial positions of the slit centers, basically the mid point between the expected
     # top and bottom values of the slit pixels
-    spatial_centers = np.array([])
+    spatial_centers = np.array([], dtype=np.int)
     for k in np.arange(0,len(initial_edges)-1):
         spatial_centers = np.append(spatial_centers,(initial_edges[k]+initial_edges[k+1])/2)
     #slit_values=np.array([])

--- a/MOSFIRE/Flats.py
+++ b/MOSFIRE/Flats.py
@@ -421,8 +421,8 @@ def find_edge_pair(data, y, roi_width, edgeThreshold=450):
 
             between = offset + width/2
             if 0 < between < len(v)-1:
-                start = np.max([0, between-2])
-                stop = np.min([len(v),between+2])
+                start = int(np.max([0, between-2]))
+                stop = int(np.min([len(v),between+2]))
                 yposs_bot_scatters.append(np.min(v[start:stop])) # 5
 
                 if False:

--- a/MOSFIRE/MosfireDrpLog.py
+++ b/MOSFIRE/MosfireDrpLog.py
@@ -30,3 +30,13 @@ critical = mylogger.critical
 
 
 #logger.info ("log started")
+
+# Add log entries for versions of numpy, matplotlib, astropy, ccdproc
+import numpy as np
+info('numpy version = {}'.format(np.__version__))
+import matplotlib
+info('matplotlib version = {}'.format(matplotlib.__version__))
+import astropy
+info('astropy version = {}'.format(astropy.__version__))
+import ccdproc
+info('ccdproc version = {}'.format(ccdproc.__version__))

--- a/MOSFIRE/Wavelength.py
+++ b/MOSFIRE/Wavelength.py
@@ -2263,7 +2263,7 @@ def fit_outwards_refit(data, bs, sol_1d, lines, options, start, bottom, top,
         """        
 
         cfit = sol_1d[1]
-        spec_here = np.ma.median(data[yhere-2:yhere+2, :], axis=0)
+        spec_here = np.ma.median(data[int(yhere)-2:int(yhere)+2, :], axis=0)
         shift = Fit.xcor_peak(spec_here, spec0, lags)
         ll_here = CV.chebval(pix - shift, cfit)
         [xs, sxs, sigmas] = find_known_lines(linelist,

--- a/MOSFIRE/Wavelength.py
+++ b/MOSFIRE/Wavelength.py
@@ -358,7 +358,7 @@ def fit_lambda(maskname,
 
     tock = time.time()
 
-    multicore = False
+    multicore = True
     if multicore:
         p = Pool()
         solutions = p.map(fit_lambda_helper, range(len(bs.ssl)))

--- a/MOSFIRE/Wavelength.py
+++ b/MOSFIRE/Wavelength.py
@@ -2248,6 +2248,9 @@ def fit_outwards_refit(data, bs, sol_1d, lines, options, start, bottom, top,
                              linelist2.
 
     '''
+    bottom = int(bottom)
+    top = int(top)
+
     lags = np.arange(-30,30)
     pix = np.arange(2048.)
     linelist = lines

--- a/MOSFIRE/Wavelength.py
+++ b/MOSFIRE/Wavelength.py
@@ -358,8 +358,8 @@ def fit_lambda(maskname,
 
     tock = time.time()
 
-
-    if True:
+    multicore = False
+    if multicore:
         p = Pool()
         solutions = p.map(fit_lambda_helper, range(len(bs.ssl)))
         p.close()


### PR DESCRIPTION
Addresses the fact that recent versions of numpy raise a `TypeError` when arrays are indexed with non integer value:

```
TypeError: slice indices must be integers or None or have an index method
```

This does *not* address a similar issue which throws a warning when arrays are indexed with a masked array of values.  This should be addressed in addition to this PR.

See #70 #73 