### PR TITLE
Filter out .original files

### DIFF
--- a/scripts/mospy_handle.py
+++ b/scripts/mospy_handle.py
@@ -28,6 +28,8 @@ files = []
 for i in range(1, len(sys.argv)):
     files.extend(glob.iglob(os.path.abspath(sys.argv[i])))
 
+files = [file for file in files if os.path.splitext(file)[1] != '.original']
+
 masks = {}
 
 


### PR DESCRIPTION
Filter out the .original files generated by `fix_long2pos_headers` from the results of handle.  Addresses #62 