### PR TITLE
Top edge of slit can’t be past detector

### DIFF
--- a/MOSFIRE/Flats.py
+++ b/MOSFIRE/Flats.py
@@ -209,7 +209,7 @@ def make_pixel_flat(data, results, options, outfile, inputs, lampsOff=None):
             hpps = [0, Detector.npix[0]]
 
         xs = np.arange(hpps[0], hpps[1])
-        top = pixel_min(tf(xs))
+        top = min([pixel_min(tf(xs)),Detector.npix[0]])
         bottom = pixel_max(bf(xs))
 
         hdu.header.set("top%2.2i" % slitno, top)


### PR DESCRIPTION
Possible fix for #111 

The polynomial fit to the top edge of the slit is not restricted anywhere to be on the detector, so under some conditions it leads to the top pixel being off the detector causing an indexing error.  I've added a simple `min` function to try to prevent that.