### PR TITLE
Fix 2D Wavelength Fitting

### DIFF
--- a/MOSFIRE/Fit.py
+++ b/MOSFIRE/Fit.py
@@ -19,6 +19,37 @@ from MOSFIRE.MosfireDrpLog import debug, info, warning, error
 #from MosfireDrpLog import debug, info, warning, error
 import unittest
 
+
+def find_shift(a, b, guess=0, maxshift=3):
+    '''Find the offset between two 1D arrays based on cross correlation.
+    
+    Intended to replace xcor and xcor_peak.
+    
+    Uses the following conditions for a point to be valid as consideration
+    for the shift result:
+    - second derivative of the correlation is negative (i.e. at local maxima)
+    - shift <= maxshift
+    
+    Works out to be about 2x speed as xcor_peak based on %timeit
+    '''
+    a = a.filled(0)
+    b = b.filled(0)
+    assert len(a) == len(b)
+    shifts = np.arange(len(a)) - len(a)/2
+    corr = np.correlate(a, b, mode='same')
+    first_derivative = np.gradient(corr)
+    second_derivative = np.gradient(first_derivative)
+
+    valid = np.where((second_derivative < 0) & (abs(shifts-guess) < maxshift))[0]
+
+    idx = np.argmax(corr[valid])
+    bestcorrindex = valid[idx]
+    shift = shifts[bestcorrindex]
+
+    return(shift)
+
+
+
 def xcor(a,b,lags):
 
     if len(a) != len(b):

--- a/MOSFIRE/Fit.py
+++ b/MOSFIRE/Fit.py
@@ -51,40 +51,6 @@ def find_shift(a, b, guess=0, maxshift=3):
     return(shift)
 
 
-
-def xcor(a,b,lags):
-
-    if len(a) != len(b):
-        error("cross correlation (xcor) requires a and b "
-                "to be of same length")
-        raise Exception(
-                "cross correlation (xcor) requires a and b "
-                "to be of same length")
-    cors = np.zeros(len(lags))
-
-    a_pad = np.zeros(len(a)+len(lags))
-    b_pad = np.zeros(len(b)+len(lags))
-
-    st = np.argmin(np.abs(lags))
-    a_pad[st:st+len(a)] = a
-    b_pad[st:st+len(b)] = b
-
-    for i in range(len(lags)):
-        cors[i] = np.correlate(a_pad, np.roll(b_pad, lags[i]), 'valid')
-
-    return cors
-
-def xcor_peak(a, b, lags):
-    '''Return the peak position in units of lags'''
-
-#     N = len(lags)
-    xcs = xcor(a, b, lags)
-
-    return lags[np.argmax(xcs)]
-
-
-
-
 # TODO: Document mpfit_* functions
 def mpfit_residuals(modelfun):
 

--- a/MOSFIRE/Fit.py
+++ b/MOSFIRE/Fit.py
@@ -44,7 +44,7 @@ def xcor(a,b,lags):
 def xcor_peak(a, b, lags):
     '''Return the peak position in units of lags'''
 
-    N = len(lags)
+#     N = len(lags)
     xcs = xcor(a, b, lags)
 
     return lags[np.argmax(xcs)]

--- a/MOSFIRE/Fit.py
+++ b/MOSFIRE/Fit.py
@@ -23,14 +23,16 @@ import unittest
 def find_shift(a, b, guess=0, maxshift=3):
     '''Find the offset between two 1D arrays based on cross correlation.
     
-    Intended to replace xcor and xcor_peak.
+    Intended to replace xcor and xcor_peak.  Works out to be about 2x speed as
+    xcor_peak based on %timeit in ipython.
     
     Uses the following conditions for a point to be valid as consideration
     for the shift result:
     - second derivative of the correlation is negative (i.e. at local maxima)
     - shift <= maxshift
     
-    Works out to be about 2x speed as xcor_peak based on %timeit
+    Given those conditions are met, the highest cross correlation value gives
+    the best value for the shift (or offset) between the two arrays.
     '''
     a = a.filled(0)
     b = b.filled(0)

--- a/MOSFIRE/Options.py
+++ b/MOSFIRE/Options.py
@@ -24,5 +24,6 @@ wavelength = {
         "version": 2,
         "fractional-wavelength-search": 0.99935, # used in determining oned wavelength solutions
         "chebyshev-degree": 5, # polynomial order for fitting wavelengths
+        "smooth": False, # smooth wavelength solution polynomial coefficients in Y direction
 }
 

--- a/MOSFIRE/Wavelength.py
+++ b/MOSFIRE/Wavelength.py
@@ -1422,47 +1422,6 @@ def estimate_half_power_points(slitno, header, bs):
     return [ np.argmin(np.abs(ll-hpp[0])), np.argmin(np.abs(ll-hpp[1])) ]
 
 
-
-def xcor_known_lines(lines, ll, spec, spec0, options):
-    """
-    lines[N]: list of lines in wavelength units
-    ll[2048]: lambda vector
-    spec[2048]: spectrum vector (as function of lambda)
-    options: wavelength options
-    """
-    inf = np.inf
-    dxs = []
-    sigs = []
-
-    pix = np.arange(2048.)
-
-    for lam in lines:
-        f = options["fractional-wavelength-search"]
-        roi = np.where((f*lam < ll) & (ll < lam/f))[0]
-
-
-
-        if not roi.any():
-            dxs.append(inf)
-            sigs.append(inf)
-            continue
-        
-        lags = np.arange(-len(roi)/2, len(roi)/2)
-        cors = Fit.xcor(spec[roi], spec0[roi], lags)
-
-        fit = Fit.mpfitpeak(lags, cors)
-
-        if (fit.perror is None) or (fit.status < 0):
-            dxs.append(inf)
-            sigs.append(inf)
-            continue
-
-        dxs.append(fit.params[1])
-        sigs.append(fit.params[2])
-
-    return list(map(np.array, [dxs, sigs]))
-
-
 def find_known_lines(lines, ll, spec, options):
     """
     lines[N]: list of lines in wavelength units
@@ -2297,7 +2256,6 @@ def fit_outwards_refit(data, bs, sol_1d, lines, options, start, bottom, top,
         cfit = sol_1d[1]
         spec_here = np.ma.median(data[int(yhere)-pmlines:int(yhere)+pmlines, :], axis=0)
         shift = Fit.find_shift(spec_here, spec0, guess=guess)
-#         shift = Fit.xcor_peak(spec_here, spec0, lags)
         ll_here = CV.chebval(pix - shift, cfit)
         [xs, sxs, sigmas] = find_known_lines(linelist,
                                              ll_here, spec_here, options)
@@ -2306,7 +2264,6 @@ def fit_outwards_refit(data, bs, sol_1d, lines, options, start, bottom, top,
             cfit2 = sol_1d2[1]
             spec_here2 = np.ma.median(data2[yhere-pmlines:yhere+pmlines, :], axis=0)
             shift2 = Fit.find_shift(spec_here2, spec2, guess=guess)
-#             shift2 = Fit.xcor_peak(spec_here2, spec2, lags)
             ll_here2 = CV.chebval(pix - shift2, cfit2)
 
             [xs2, sxs2, sigmas2] = find_known_lines(linelist2,

--- a/MOSFIRE/Wavelength.py
+++ b/MOSFIRE/Wavelength.py
@@ -1122,7 +1122,9 @@ def pick_linelist(header, neon=False, argon=False, short_exp = False):
              13421.579])
 
     if (band == 'K') and short_exp:
-        # remove: 19518.4784 , 19593.2626 ,  19618.5719 ,19678.046 ,19839.7764 ,20193.1799 ,20499.237 ,21279.1406 ,21580.5093 ,21711.1235 , 21873.507 ,22460.4183 ,22690.1765 ,22985.9156,23914.55, 24041.62,22742.1907 
+        # remove: 19518.4784 , 19593.2626 ,  19618.5719 ,19678.046 ,19839.7764 ,
+        # 20193.1799 ,20499.237 ,21279.1406 ,21580.5093 ,21711.1235 , 21873.507 
+        #,22460.4183 ,22690.1765 ,22985.9156,23914.55, 24041.62,22742.1907 
         lines = np.array([
         19642.4493 , 
         19701.6455 , 19771.9063 , 
@@ -1336,7 +1338,7 @@ def refine_wavelength_guess(wave,spec,linelist):
     """
 
     # find what is the average peak height to construct the reference
-    # spectrum template                                                                                                                          
+    # spectrum template
     peaks = signal.find_peaks_cwt(spec,np.array([2.0,4.0]),noise_perc=5.0,min_snr =1.5)
     avePeak = np.mean(spec[peaks])
 
@@ -1348,11 +1350,11 @@ def refine_wavelength_guess(wave,spec,linelist):
     corr = signal.correlate(spec,refSpec,mode='same')
     lags = np.arange(len(spec))-len(spec)/2
 
-    # peak velocity corresponding to the pixel peak                                                                                                  
+    # peak velocity corresponding to the pixel peak
     peakInd = np.argmax(corr)
     peakLag = lags[peakInd]
 
-    # return the number of pixels that need to be shifted                                                                                             
+    # return the number of pixels that need to be shifted
     return -peakLag
 
 def plot_mask_solution_ds9(fname, maskname, options):
@@ -2014,7 +2016,8 @@ class InteractiveSolution:
 
         actions_mouseless = {".": self.fastforward, "n": self.nextobject, "p":
                 self.prevobject, "q": self.quit, "r": self.reset, "f":
-                self.fit_event, "k": self.toggle_sigma_clip, "\\": self.fit_event, "b": self.toggle_noninteractive}
+                self.fit_event, "k": self.toggle_sigma_clip, "\\": self.fit_event,
+                "b": self.toggle_noninteractive}
 
         actions = { "c": self.shift, "d": self.drop_point,
                 "z": self.zoom, "x": self.unzoom, "s": self.savefig}
@@ -2324,13 +2327,13 @@ def fit_outwards_refit(data, bs, sol_1d, lines, options, start, bottom, top,
                 sds, 'lambdaMAD': mads, "positions": np.array(positions)}
 
     """ Start of main section of fit_outwards """
-    pix = np.arange(2048.)
+#     pix = np.arange(2048.)
 
-    positions = np.concatenate((np.arange(start, top, 1), 
-        np.arange(start-1,bottom,-1)))
+#     positions = np.concatenate((np.arange(start, top, 1), 
+#         np.arange(start-1,bottom,-1)))
     positions = np.arange(bottom, top, 1)
     info("Computing 0 spectrum at %i" % start)
-    spec0 = np.ma.median(data[start-1:start+1, :], axis=0)
+#     spec0 = np.ma.median(data[start-1:start+1, :], axis=0)
     if data2 is not None:
             spec2 = np.ma.median(data2[start-1:start+1, :], axis=0)
     params = sweep(positions)

--- a/MOSFIRE/Wavelength.py
+++ b/MOSFIRE/Wavelength.py
@@ -2264,10 +2264,11 @@ def fit_outwards_refit(data, bs, sol_1d, lines, options, start, bottom, top,
         for the arc line data. We want to fit both Ne and
         Argon simultaneously.
         
-        """        
+        """
 
+        pmlines = 1
         cfit = sol_1d[1]
-        spec_here = np.ma.median(data[int(yhere)-2:int(yhere)+2, :], axis=0)
+        spec_here = np.ma.median(data[int(yhere)-pmlines:int(yhere)+pmlines, :], axis=0)
         shift = Fit.find_shift(spec_here, spec0, guess=guess)
 #         shift = Fit.xcor_peak(spec_here, spec0, lags)
         ll_here = CV.chebval(pix - shift, cfit)
@@ -2276,7 +2277,7 @@ def fit_outwards_refit(data, bs, sol_1d, lines, options, start, bottom, top,
 
         if data2 is not None:
             cfit2 = sol_1d2[1]
-            spec_here2 = np.ma.median(data2[yhere-2:yhere+2, :], axis=0)
+            spec_here2 = np.ma.median(data2[yhere-pmlines:yhere+pmlines, :], axis=0)
             shift2 = Fit.find_shift(spec_here2, spec2, guess=guess)
 #             shift2 = Fit.xcor_peak(spec_here2, spec2, lags)
             ll_here2 = CV.chebval(pix - shift2, cfit2)


### PR DESCRIPTION
Several significant changes to the Wavelength code were made:

First, the function to determine the estimated offset between rows of pixels was changed to use the new `find_shift` method rather than the `xcor` and `xcor_peak` methods.  This new method is similar, but works out to be about 2x faster when timed using the `%timeit` tool in ipython.

Second, that shift determination was constrained to be within 3 pixels of the *neighboring* line, rather than within 30 pixels of the starting line.  This ensures a much more continuous wavelength solution in the Y direction.

Third, when fitting Chebyshev polynomials to the wavelength solution for each line, an extra step is added (the `smooth_solution` method) to median filter each Chebyshev coefficient in the Y direction to limit the changes in wavelength solution from pixel line to adjacent pixel line.

This appears to have fixed the problem in #115, though further testing to ensure that it works in all cases is still pending.