### PR TITLE
Output standard extraction as well

### DIFF
--- a/MOSFIRE/Extract.py
+++ b/MOSFIRE/Extract.py
@@ -254,10 +254,9 @@ class ApertureEditor(object):
                                 facecolor='y', alpha=0.3,
                                 )
                 pl.text(ap['position']-ap['width']+1,
-                             self.ydata.max() + 0.05*yspan,
-                             'position={:.0f}\nwidth={:.0f}'.format(ap['position'],
-                                                                    ap['width']),
-                             )
+                        self.ydata.max() + 0.05*yspan,
+                        f"pos={ap['position']:.0f}\nwidth={ap['width']:.0f}",
+                        )
                 pl.draw()
             pl.show()
 


### PR DESCRIPTION
For the 1D spectral extraction step, this PR adds the standard spectral extraction version to the output (in both the fits and png files) in addition to the optimal spectral extraction of (Howe 1986).

In the fits files, the standard spectral extraction is in the 3rd (signal) and 4th (uncertainty) extensions.  In the png files, there is now a second plot below the first plot.