### PR TITLE
Fix lampOffList typo in Flats.py (introduced in: f35382e)

### DIFF
--- a/MOSFIRE/Flats.py
+++ b/MOSFIRE/Flats.py
@@ -138,7 +138,7 @@ def handle_flats(flatlist, maskname, band, options, extension=None,edgeThreshold
     debug("Combined '%s' to '%s'" % (flatlist, maskname))
 #     info("Combined flats for '%s'" % (maskname))
     path = "combflat_2d_%s.fits" % band
-    if lampsOffList != None:
+    if lampOffList != None:
         debug("Using on-off flat for K band")
         path = os.path.join("combflat_lamps_on_2d_{:s}.fits".format(band))
     (header, data) = IO.readfits(path, use_bpm=True)


### PR DESCRIPTION
The variable `lampsOffList` does not exist. I think should be `lampOffList`.